### PR TITLE
Better word separation

### DIFF
--- a/bm/squirt.js
+++ b/bm/squirt.js
@@ -229,7 +229,8 @@ sq.host =  window.location.search.match('sq-dev') ?
     return function textToNodes(text) {
       text = "3\n 2\n 1\n " + text.trim('\n').replace(/\s+\n/g,'\n');
       return text
-             .split(' ')
+             .replace(/[\,\.\!\:\;](?![\"\'\)\]\}])/g, "$& ")
+             .split(/[\s]+/g)
              .filter(function(word){ return word.length; })
              .map(wordToNode);
     };


### PR DESCRIPTION
Hello there!

Very neat stuff!  I noticed that squirt wasn't separating words out very intelligently, and wanted to lend a hand.

This pull does two things:
1. It separates words based on all whitespace characters (tab, newline).  Previously, they were split by only spaces.
2. It splits up words with non-whitespace characters, such as punctuation.  Because of the way that `textContent` works, adjacent words that are wrapped in tags (e.g. `<b>This,</b> and this`) will get returned as single words (`['This,and', 'this']`).  This pull adds an extra space after all punctuation, which often helps with words that run-together.

Thanks!

/cc #10, #17
