### PR TITLE
Firefox `selection.toString` method call added

### DIFF
--- a/bm/squirt.js
+++ b/bm/squirt.js
@@ -30,6 +30,10 @@ sq.host =  window.location.search.match('sq-dev') ?
 
       // text source: selection
       var selection = window.getSelection();
+      var selectionText = selection.toString();
+      if(selectionText) {
+        return read(selectionText);
+      }
       if(selection.type == 'Range') {
         var container = document.createElement("div");
         for (var i = 0, len = selection.rangeCount; i < len; ++i) {


### PR DESCRIPTION
This should enable selection to be used for reading in Firefox browsers. See bug #28.
I've tested it with Firefox and Chrome browsers on Windows. I was using the following bookmarklet code:

```
javascript:(function(){if(window.sq){window.sq.closed&&window.document.dispatchEvent(new%20Event('squirt.again'));}else{window.sq={};window.sq.userId='27ac432c-8659-4b64-9930-6e72ea11b9c6';s=document.createElement('script');s.src='https://raw.github.com/zloster/squirt/gh-pages/bm/squirt.js';s.s=window.location.search;s.idx=s.s.indexOf('sq-dev');if(s.idx!=-1){s.ampIdx=s.s.indexOf('&');s.host=s.s.substring(s.idx+7,s.ampIdx==-1?s.s.length:s.ampIdx);s.src='http://'+(s.host?s.host:'localhost')+':4000/zloster/squirt/gh-pages/bm/squirt.js';}document.body.appendChild(s);}})();
```
