### PR TITLE
Close the wpm selector when play is invoked

### DIFF
--- a/bm/squirt.js
+++ b/bm/squirt.js
@@ -117,6 +117,7 @@ sq.host =  window.location.search.match('sq-dev') ?
     function play(e){
       sq.paused = false;
       dispatch('squirt.pause.after');
+      toggle(document.querySelector('.sq .wpm-selector'));
       nextNode(e.jumped);
       e.notForKeen === undefined && Keen.addEvent('play');
     };


### PR DESCRIPTION
This pull request closes the wpm selector when pressing play with the wpm selector open.

This closes issue #56.
