### PR TITLE
Make squirt recognise spaces before elements

### DIFF
--- a/readability.js
+++ b/readability.js
@@ -490,7 +490,7 @@ var readability = {
       child = node.childNodes[childIdx];
       nodeName = child.nodeName.toLowerCase();
       if(nodeName == "#text"){
-        text += child.nodeValue.trim('\n');
+        text += child.nodeValue.replace(/^\n+/, "").replace(/\n+$/, "");
       } else {
         text += extract(child);
       }


### PR DESCRIPTION
This pull request fixes issue #39 (previously #72) where squirt would not recognise spaces before inline elements such as hyperlinks.
